### PR TITLE
add allpets option to finish command

### DIFF
--- a/bot/commands/OSRS_Fun/finish.js
+++ b/bot/commands/OSRS_Fun/finish.js
@@ -1608,9 +1608,22 @@ ${lootMSG.join('\n')}`);
 					`It took you ${kc.toLocaleString()} Barrows Chests to get all the Barrows Pieces. You also got ${duplicates} duplicate items.`
 				);
 			}
+			case 'ALLPETS':
+			case 'ALLPET': {
+				const petsRecieved = [];		
+				pets.forEach(function(pet){
+					let kcpet = 1;
+					while(!roll(pet.chance)){
+						kcpet++;
+					}
+					petsRecieved.push(kcpet.toLocaleString());
+				});
+				const embedPets = await this.getAllpetsEmbed(7981338, [petsRecieved]);
+				return msg.send(embedPets);
+			}
 			default:
 				return msg.send("I don't have that monster!");
-			}
+		}
 	}
 
 };

--- a/bot/extendables/getAllpetsEmbed.js
+++ b/bot/extendables/getAllpetsEmbed.js
@@ -1,0 +1,80 @@
+const { Extendable, Command } = require('klasa');
+const { MessageEmbed } = require('discord.js');
+const pets = require('../../data/pets');
+
+class getAllpetsEmbed extends Extendable {
+
+	constructor(...args) {
+		super(...args, {
+			appliesTo: [Command],
+			enabled: true,
+			klasa: true
+		});
+	}
+
+	async getAllpetsEmbed(color, [PetsRecieved]) {
+		const embed = new MessageEmbed()
+			.setColor(color)
+			.addField(
+				'\u200b',
+				`
+				${pets[0].emoji} ${PetsRecieved[0]} Red Chins
+				${pets[1].emoji} ${PetsRecieved[1]} KC
+				${pets[2].emoji} ${PetsRecieved[2]} Magic Logs
+				${pets[3].emoji} ${PetsRecieved[3]} Masters
+				${pets[4].emoji} ${PetsRecieved[4]} KC
+				${pets[5].emoji} ${PetsRecieved[5]} Argougne Laps
+				${pets[6].emoji} ${PetsRecieved[6]} Monkfish
+				${pets[7].emoji} ${PetsRecieved[7]} KC
+				${pets[8].emoji} ${PetsRecieved[8]} KC
+				${pets[9].emoji} ${PetsRecieved[9]} Raids
+				${pets[10].emoji} ${PetsRecieved[10]} KC
+				${pets[11].emoji} ${PetsRecieved[11]} KC
+				${pets[12].emoji} ${PetsRecieved[12]} KC
+				${pets[13].emoji} ${PetsRecieved[13]} KC`,
+				true
+			)
+			.addField(
+				'\u200b',
+				`
+				${pets[14].emoji} ${PetsRecieved[14]} KC
+				${pets[15].emoji} ${PetsRecieved[15]} KC
+				${pets[16].emoji} ${PetsRecieved[16]} KC
+				${pets[17].emoji} ${PetsRecieved[17]} KC
+				${pets[18].emoji} ${PetsRecieved[18]} KC
+				${pets[19].emoji} ${PetsRecieved[19]} Gambles
+				${pets[20].emoji} ${PetsRecieved[20]} KC
+				${pets[21].emoji} ${PetsRecieved[21]} KC
+				${pets[22].emoji} ${PetsRecieved[22]} KC
+				${pets[23].emoji} ${PetsRecieved[23]} KC
+				${pets[24].emoji} ${PetsRecieved[24]} KC
+				${pets[25].emoji} ${PetsRecieved[25]} Nature Runes
+				${pets[26].emoji} ${PetsRecieved[26]} Paydirt
+				${pets[27].emoji} ${PetsRecieved[27]} Ardougne Knights`,
+				true
+			)
+			.addField(
+				'\u200b',
+				`
+				${pets[28].emoji} ${PetsRecieved[28]} KC
+				${pets[29].emoji} ${PetsRecieved[29]} KC
+				${pets[30].emoji} ${PetsRecieved[30]} Magic Trees
+				${pets[31].emoji} ${PetsRecieved[31]} KC
+				${pets[32].emoji} ${PetsRecieved[32]} KC
+				${pets[33].emoji} ${PetsRecieved[33]} KC
+				${pets[34].emoji} ${PetsRecieved[34]} KC
+				${pets[35].emoji} ${PetsRecieved[35]} KC
+				${pets[36].emoji} ${PetsRecieved[36]} KC
+				${pets[37].emoji} ${PetsRecieved[37]} KC
+				${pets[38].emoji} ${PetsRecieved[38]} Harvests
+				${pets[39].emoji} ${PetsRecieved[39]} KC
+				${pets[40].emoji} ${PetsRecieved[40]} Raids
+				${pets[41].emoji} ${PetsRecieved[41]} KC`,
+				true
+			);
+		return embed;
+	}
+
+}
+
+module.exports = getAllpetsEmbed;

--- a/data/pets.js
+++ b/data/pets.js
@@ -26,7 +26,7 @@ module.exports = [
 	{
 		id: 4,
 		emoji: '<:Bloodhound:324127375602483212>',
-		chance: 3000,
+		chance: 1000,
 		name: 'Bloodhound',
 		type: 'SPECIAL',
 		altNames: ['BLOODHOUND']
@@ -130,7 +130,7 @@ module.exports = [
 	{
 		id: 17,
 		emoji: '<:Pet_kraken:324127377477206016>',
-		chance: 5000,
+		chance: 3000,
 		name: 'Kraken',
 		type: 'BOSS',
 		altNames: ['KRAKEN']


### PR DESCRIPTION
Creates the option in finish for all pets to be rolled until received.
An embed gets built and then sent out with the resulting values.
Also corrects the Bloodhound and Kraken pet chances in the pets array.
closes #35 