### PR TITLE
Updated cmd.js

### DIFF
--- a/src/commands/Configuration/73.js
+++ b/src/commands/Configuration/73.js
@@ -8,7 +8,7 @@ module.exports = class extends Command {
 			description: "Enables/disables, reacts with 😂 everytime somebody says '73'.",
 			runIn: ['text'],
 			usage: '<enable|disable>',
-			permissionLevel: 7
+			permissionLevel: 6
 		});
 	}
 

--- a/src/commands/Configuration/ashtweets.js
+++ b/src/commands/Configuration/ashtweets.js
@@ -7,7 +7,7 @@ module.exports = class extends Command {
 			description: 'Receive every tweet from God Ash in your discord channel!.',
 			runIn: ['text'],
 			usage: '<enable|disable>',
-			permissionLevel: 7,
+			permissionLevel: 6,
 			requiredPermissions: ['EMBED_LINKS']
 		});
 	}

--- a/src/commands/Configuration/cmd.js
+++ b/src/commands/Configuration/cmd.js
@@ -9,7 +9,7 @@ module.exports = class extends Command {
 			description: 'Enable and Disable certain bot commands in your guild. Admins only.',
 			usage: '<enable|disable> <command:cmd>',
 			usageDelim: ' ',
-			permissionLevel: 7
+			permissionLevel: 6
 		});
 	}
 

--- a/src/commands/Configuration/hcimdeaths.js
+++ b/src/commands/Configuration/hcimdeaths.js
@@ -7,7 +7,7 @@ module.exports = class extends Command {
 			description: 'Enables/disables HCIM Death Tweets from @HCIM Deaths on Twitter.',
 			runIn: ['text'],
 			usage: '<enable|disable>',
-			permissionLevel: 7,
+			permissionLevel: 6,
 			requiredPermissions: ['EMBED_LINKS']
 		});
 	}

--- a/src/commands/Configuration/jmodcomments.js
+++ b/src/commands/Configuration/jmodcomments.js
@@ -9,7 +9,7 @@ module.exports = class extends Command {
 				'Enables/disables the function which sends comments/posts from Jmods on reddit.',
 			runIn: ['text'],
 			usage: '<enable|disable>',
-			permissionLevel: 7
+			permissionLevel: 6
 		});
 	}
 

--- a/src/commands/Configuration/levelmessages.js
+++ b/src/commands/Configuration/levelmessages.js
@@ -10,7 +10,7 @@ module.exports = class extends Command {
 				'Enables/disables the function which sends update notifications for users with RSN set in the server.',
 			runIn: ['text'],
 			usage: '<enable|disable>',
-			permissionLevel: 7
+			permissionLevel: 6
 		});
 	}
 

--- a/src/commands/Configuration/petmessages.js
+++ b/src/commands/Configuration/petmessages.js
@@ -9,7 +9,7 @@ module.exports = class extends Command {
 				'Enables/disables Pet Messages, which rolls a chance at a pet on every message in a channel.',
 			runIn: ['text'],
 			usage: '<enable|disable>',
-			permissionLevel: 7
+			permissionLevel: 6
 		});
 	}
 

--- a/src/commands/Configuration/prefix.js
+++ b/src/commands/Configuration/prefix.js
@@ -3,7 +3,7 @@ const { Command } = require('klasa');
 module.exports = class extends Command {
 	constructor(...args) {
 		super(...args, {
-			permissionLevel: 7,
+			permissionLevel: 6,
 			runIn: ['text'],
 			description: 'Change the command prefix the bot uses in your server.',
 			usage: '[prefix:str{1,3}]'

--- a/src/commands/Configuration/streamertweets.js
+++ b/src/commands/Configuration/streamertweets.js
@@ -8,7 +8,7 @@ module.exports = class extends Command {
 				'Enables/disables the Streamer Tweets function which sends tweets from OSRS Streamers.',
 			runIn: ['text'],
 			usage: '<enable|disable>',
-			permissionLevel: 7,
+			permissionLevel: 6,
 			requiredPermissions: ['EMBED_LINKS']
 		});
 	}

--- a/src/commands/Configuration/tweets.js
+++ b/src/commands/Configuration/tweets.js
@@ -8,7 +8,7 @@ module.exports = class extends Command {
 				'Enables/disables the JMod Tweets function which sends tweets from OSRS JMods.',
 			runIn: ['text'],
 			usage: '<enable|disable>',
-			permissionLevel: 7,
+			permissionLevel: 6,
 			requiredPermissions: ['EMBED_LINKS']
 		});
 	}

--- a/src/commands/Configuration/twitchnotifications.js
+++ b/src/commands/Configuration/twitchnotifications.js
@@ -3,7 +3,7 @@ const { Command } = require('klasa');
 module.exports = class extends Command {
 	constructor(...args) {
 		super(...args, {
-			permissionLevel: 7,
+			permissionLevel: 6,
 			subcommands: true,
 			aliases: ['tn'],
 			description:


### PR DESCRIPTION
Updated the Cmd.Js to require permission level 6 rather than 7 as per https://klasa.js.org/#/docs/klasa/stable/Tutorials/UnderstandingPermissionLevels

This should stop the "You do not have permission to use this command." error for people with Manage Server rights. 

Klasa states the following 

6 | false | Members of guilds must have 'MANAGE_GUILD' permission
7 | false | Guild Owner

