### PR TITLE
sell: replace apostrophe in item names

### DIFF
--- a/src/commands/Fun/sell.ts
+++ b/src/commands/Fun/sell.ts
@@ -29,7 +29,8 @@ export default class extends BotCommand {
 	}
 
 	async run(msg: KlasaMessage, [quantity, itemName]: [number, string]) {
-		const osItem = Items.get(itemName);
+		let re = /’/gi;
+		const osItem = Items.get(itemName.replace(re,"'"));
 		if (!osItem) throw `That item doesnt exist.`;
 		if (
 			specialUntradeables.includes(osItem.id) ||


### PR DESCRIPTION
phones seem to have a different default apostrophe that doesnt let the item name evaluate correctly this replaces that with the one thats expected