### PR TITLE
Increase response timer for continuing minion trip with "yes"

### DIFF
--- a/src/tasks/minions/monsterActivity.ts
+++ b/src/tasks/minions/monsterActivity.ts
@@ -63,7 +63,7 @@ export default class extends Task {
 
 		channel
 			.awaitMessages(mes => mes.author === user && saidYes(mes.content), {
-				time: Time.Minute * 2,
+				time: Time.Minute * 5,
 				max: 1
 			})
 			.then(messages => {


### PR DESCRIPTION
 * The two minute timer led to a large amount of my attempts to extend the minion trip being rejected.  Increasing it to 5 minutes gives a much more reasonable window for users realizing that their minion has returned and quickly sending them back.