### PR TITLE
Improve collection log types

### DIFF
--- a/src/lib/collectionLog.ts
+++ b/src/lib/collectionLog.ts
@@ -1,4 +1,5 @@
 import { removeDuplicatesFromArray } from './util';
+import { CollectionLogTypeName, CollectionLogType } from './types/index';
 
 export const bosses = {
 	Zulrah: [12921, 12936, 13201, 13200, 6571, 12927, 12922, 12932],
@@ -559,9 +560,9 @@ export const clues = {
 	'9421': [20128, 20131, 20134, 20137, 20140]
 };
 
-export const collectionLogTypes = [
+export const collectionLogTypes: CollectionLogType[] = [
 	{
-		name: 'Overall' as const,
+		name: CollectionLogTypeName.Overall,
 		aliases: ['all', 'overall'],
 		items: removeDuplicatesFromArray(
 			[...Object.values(bosses), ...Object.values(clues), ...Object.values(pets)].flat(
@@ -570,22 +571,18 @@ export const collectionLogTypes = [
 		)
 	},
 	{
-		name: 'Boss' as const,
+		name: CollectionLogTypeName.Boss,
 		aliases: ['bosses', 'boss'],
 		items: bosses
 	},
 	{
-		name: 'Clue' as const,
+		name: CollectionLogTypeName.Clue,
 		aliases: ['clues', 'clue'],
 		items: clues
 	},
 	{
-		name: 'Pets' as const,
+		name: CollectionLogTypeName.Pets,
 		aliases: ['pet', 'pets'],
 		items: pets
 	}
 ];
-
-type ArrayElementOf<T> = T extends (infer E)[] ? E : never;
-
-export type CollectionLogType = ArrayElementOf<typeof collectionLogTypes>;

--- a/src/lib/collectionLog.ts
+++ b/src/lib/collectionLog.ts
@@ -561,27 +561,31 @@ export const clues = {
 
 export const collectionLogTypes = [
 	{
-		name: 'Overall',
+		name: 'Overall' as const,
 		aliases: ['all', 'overall'],
 		items: removeDuplicatesFromArray(
 			[...Object.values(bosses), ...Object.values(clues), ...Object.values(pets)].flat(
 				Infinity
-			)
+			) as number[]
 		)
 	},
 	{
-		name: 'Boss',
+		name: 'Boss' as const,
 		aliases: ['bosses', 'boss'],
 		items: bosses
 	},
 	{
-		name: 'Clue',
+		name: 'Clue' as const,
 		aliases: ['clues', 'clue'],
 		items: clues
 	},
 	{
-		name: 'Pets',
+		name: 'Pets' as const,
 		aliases: ['pet', 'pets'],
 		items: pets
 	}
 ];
+
+type ArrayElementOf<T> = T extends (infer E)[] ? E : never;
+
+export type CollectionLogType = ArrayElementOf<typeof collectionLogTypes>;

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -1,4 +1,5 @@
 import { Activity } from '../constants';
+import * as collectionLog from '../collectionLog';
 import Monster from 'oldschooljs/dist/structures/Monster';
 
 export interface Bank {
@@ -114,3 +115,20 @@ export interface JMod {
 	redditUsername: string;
 	formattedName: string;
 }
+
+export enum CollectionLogTypeName {
+	Overall = 'Overall',
+	Boss = 'Boss',
+	Clue = 'Clue',
+	Pets = 'Pets'
+}
+
+export type CollectionLogType = { aliases: string[] } & (
+	| {
+			name: CollectionLogTypeName.Overall;
+			items: number[];
+	  }
+	| { name: CollectionLogTypeName.Boss; items: typeof collectionLog.bosses }
+	| { name: CollectionLogTypeName.Clue; items: typeof collectionLog.clues }
+	| { name: CollectionLogTypeName.Pets; items: typeof collectionLog.pets }
+);

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -227,7 +227,7 @@ export function roll(max: number) {
 	return Math.floor(Math.random() * max + 1) === 1;
 }
 
-export function removeDuplicatesFromArray(arr: unknown[]) {
+export function removeDuplicatesFromArray<T>(arr: T[]): T[] {
 	return [...new Set(arr)];
 }
 

--- a/src/tasks/bankImage.ts
+++ b/src/tasks/bankImage.ts
@@ -14,8 +14,9 @@ import {
 	saveCtx,
 	restoreCtx
 } from '../lib/util';
-import { Bank } from '../lib/types';
 import { ClientSettings } from '../lib/ClientSettings';
+import { Bank } from '../lib/types/index';
+import { CollectionLogType } from '../lib/collectionLog';
 
 registerFont('./resources/osrs-font.ttf', { family: 'Regular' });
 registerFont('./resources/osrs-font-compact.otf', { family: 'Regular' });
@@ -284,7 +285,7 @@ export default class BankImageTask extends Task {
 	async generateCollectionLogImage(
 		collectionLog: Bank,
 		title: string = '',
-		type: any
+		type: CollectionLogType
 	): Promise<Buffer> {
 		const canvas = createCanvas(488, 331);
 		const ctx = canvas.getContext('2d');

--- a/src/tasks/bankImage.ts
+++ b/src/tasks/bankImage.ts
@@ -15,8 +15,7 @@ import {
 	restoreCtx
 } from '../lib/util';
 import { ClientSettings } from '../lib/ClientSettings';
-import { Bank } from '../lib/types/index';
-import { CollectionLogType } from '../lib/collectionLog';
+import { Bank, CollectionLogType } from '../lib/types/index';
 
 registerFont('./resources/osrs-font.ttf', { family: 'Regular' });
 registerFont('./resources/osrs-font-compact.otf', { family: 'Regular' });


### PR DESCRIPTION
Tighten up types involving collection log
   * Give a type to the `type` parameter used in `generateCollectionLogImage` derived from the array which it is pulled from
  * Make `removeDuplicatesFromArray` generic to preserve types
  * Make the desriminator key `name` of `collectionLogTypes` `const` to allow it to be matched on more clearly

Update `README.md` with a few other required steps for building
   * A couple new config items have been added since it was last updated, and a trivia database is required