### PR TITLE
fix incorrect amulet of glory (t) in cl

### DIFF
--- a/src/lib/collectionLog.ts
+++ b/src/lib/collectionLog.ts
@@ -744,7 +744,7 @@ export const cluesHard = {
 		'Robin hood hat',
 		'Magic longbow',
 		'Magic shortbow',
-		'Amulet of glory (t4)',
+		'Amulet of glory (t)',
 		'Explorer backpack',
 		'Rune cane',
 		'Zombie head'


### PR DESCRIPTION
The amulet of glory(t) in the collection log was charged while the one on the loot tables and in the main game are not.