### PR TITLE
fix mining pet chance

### DIFF
--- a/src/tasks/minions/miningActivity.ts
+++ b/src/tasks/minions/miningActivity.ts
@@ -59,8 +59,8 @@ export default class extends Task {
 			[ore.id]: quantity
 		};
 
-		// Roll for pet at 1.5x chance
-		if (ore.petChance && rand(1, ore.petChance * 1.5) < quantity) {
+		// Roll for pet
+		if (ore.petChance && roll(ore.petChance - user.skillLevel(SkillsEnum.Mining) * 25)) {
 			loot[itemID('Rock golem')] = 1;
 			str += `\nYou have a funny feeling you're being followed...`;
 			this.client.emit(


### PR DESCRIPTION
instead of having 1 in base chance * 1.5, use  1 in B - (Lvl * 25), where B is the base chance and Lvl is the player's Mining level. 