### PR TITLE
monster boosts and other stuff

### DIFF
--- a/src/commands/Minion/minion.ts
+++ b/src/commands/Minion/minion.ts
@@ -23,6 +23,8 @@ import reducedTimeFromKC from '../../lib/minions/functions/reducedTimeFromKC';
 import { SkillsEnum } from '../../lib/skilling/types';
 import getUsersPerkTier from '../../lib/util/getUsersPerkTier';
 import { formatItemReqs } from '../../lib/util/formatItemReqs';
+import hasArrayOfItemsEquipped from '../../lib/gear/functions/hasArrayOfItemsEquipped';
+import itemID from '../../lib/util/itemID';
 
 const invalidClue = (prefix: string) =>
 	`That isn't a valid clue tier, the valid tiers are: ${clueTiers
@@ -462,6 +464,22 @@ ${Emoji.QuestIcon} QP: ${msg.author.settings.get(UserSettings.QP)}
 
 		const randomAddedDuration = rand(1, 20);
 		duration += (randomAddedDuration * duration) / 100;
+
+		if (
+			hasArrayOfItemsEquipped(
+				[
+					'Graceful hood',
+					'Graceful top',
+					'Graceful legs',
+					'Graceful gloves',
+					'Graceful boots',
+					'Graceful cape'
+				].map(itemID),
+				msg.author.settings.get(UserSettings.Gear.Skilling)
+			)
+		) {
+			duration *= 0.9;
+		}
 
 		if (isWeekend()) {
 			duration *= 0.9;

--- a/src/commands/Minion/quest.ts
+++ b/src/commands/Minion/quest.ts
@@ -5,6 +5,8 @@ import { Time, Activity, Tasks, MAX_QP } from '../../lib/constants';
 import addSubTaskToActivityTask from '../../lib/util/addSubTaskToActivityTask';
 import { QuestingActivityTaskOptions } from '../../lib/types/minions';
 import { UserSettings } from '../../lib/settings/types/UserSettings';
+import itemID from '../../lib/util/itemID';
+import hasArrayOfItemsEquipped from '../../lib/gear/functions/hasArrayOfItemsEquipped';
 
 export default class extends BotCommand {
 	public constructor(store: CommandStore, file: string[], directory: string) {
@@ -34,9 +36,21 @@ export default class extends BotCommand {
 
 		let duration = Time.Minute * 30;
 
-		if (isWeekend()) {
-			boosts.push(`10% for Weekend`);
+		if (
+			hasArrayOfItemsEquipped(
+				[
+					'Graceful hood',
+					'Graceful top',
+					'Graceful legs',
+					'Graceful gloves',
+					'Graceful boots',
+					'Graceful cape'
+				].map(itemID),
+				msg.author.settings.get(UserSettings.Gear.Skilling)
+			)
+		) {
 			duration *= 0.9;
+			boosts.push(`10% for Graceful`);
 		}
 
 		const data: QuestingActivityTaskOptions = {

--- a/src/commands/Minion/quest.ts
+++ b/src/commands/Minion/quest.ts
@@ -1,6 +1,6 @@
 import { CommandStore, KlasaMessage } from 'klasa';
 import { BotCommand } from '../../lib/BotCommand';
-import { formatDuration, rand, isWeekend } from '../../lib/util';
+import { formatDuration, rand } from '../../lib/util';
 import { Time, Activity, Tasks, MAX_QP } from '../../lib/constants';
 import addSubTaskToActivityTask from '../../lib/util/addSubTaskToActivityTask';
 import { QuestingActivityTaskOptions } from '../../lib/types/minions';
@@ -66,7 +66,7 @@ export default class extends BotCommand {
 		msg.author.incrementMinionDailyDuration(duration);
 		let response = `${
 			msg.author.minionName
-		} is now completing quests, they'll come back in around ${formatDuration(duration)}.`;
+			} is now completing quests, they'll come back in around ${formatDuration(duration)}.`;
 
 		if (boosts.length > 0) {
 			response += `\n\n **Boosts:** ${boosts.join(', ')}.`;

--- a/src/commands/Minion/quest.ts
+++ b/src/commands/Minion/quest.ts
@@ -66,7 +66,7 @@ export default class extends BotCommand {
 		msg.author.incrementMinionDailyDuration(duration);
 		let response = `${
 			msg.author.minionName
-			} is now completing quests, they'll come back in around ${formatDuration(duration)}.`;
+		} is now completing quests, they'll come back in around ${formatDuration(duration)}.`;
 
 		if (boosts.length > 0) {
 			response += `\n\n **Boosts:** ${boosts.join(', ')}.`;

--- a/src/commands/Minion/quest.ts
+++ b/src/commands/Minion/quest.ts
@@ -1,6 +1,6 @@
 import { CommandStore, KlasaMessage } from 'klasa';
 import { BotCommand } from '../../lib/BotCommand';
-import { formatDuration, rand } from '../../lib/util';
+import { formatDuration, rand, isWeekend } from '../../lib/util';
 import { Time, Activity, Tasks, MAX_QP } from '../../lib/constants';
 import addSubTaskToActivityTask from '../../lib/util/addSubTaskToActivityTask';
 import { QuestingActivityTaskOptions } from '../../lib/types/minions';
@@ -30,7 +30,14 @@ export default class extends BotCommand {
 			return msg.send(msg.author.minionStatus);
 		}
 
-		const duration = Time.Minute * 30;
+		const boosts = [];
+
+		let duration = Time.Minute * 30;
+
+		if (isWeekend()) {
+			boosts.push(`10% for Weekend`);
+			duration *= 0.9;
+		}
 
 		const data: QuestingActivityTaskOptions = {
 			type: Activity.Questing,
@@ -43,10 +50,14 @@ export default class extends BotCommand {
 
 		await addSubTaskToActivityTask(this.client, Tasks.SkillingTicker, data);
 		msg.author.incrementMinionDailyDuration(duration);
-		return msg.send(
-			`${
-				msg.author.minionName
-			} is now completing quests, they'll come back in around ${formatDuration(duration)}.`
-		);
+		let response = `${
+			msg.author.minionName
+		} is now completing quests, they'll come back in around ${formatDuration(duration)}.`;
+
+		if (boosts.length > 0) {
+			response += `\n\n **Boosts:** ${boosts.join(', ')}.`;
+		}
+
+		return msg.send(response);
 	}
 }

--- a/src/commands/Minion/rc.ts
+++ b/src/commands/Minion/rc.ts
@@ -81,10 +81,10 @@ export default class extends BotCommand {
 			boosts.push(`10% for Graceful`);
 		}
 
-		if (msg.author.skillLevel(SkillsEnum.Agility) > 90) {
+		if (msg.author.skillLevel(SkillsEnum.Agility) >= 90) {
 			tripLength -= rune.tripLength * 0.1;
 			boosts.push(`10% for 90+ Agility`);
-		} else if (msg.author.skillLevel(SkillsEnum.Agility) > 60) {
+		} else if (msg.author.skillLevel(SkillsEnum.Agility) >= 60) {
 			tripLength -= rune.tripLength * 0.05;
 			boosts.push(`5% for 60+ Agility`);
 		}

--- a/src/commands/Minion/skills.ts
+++ b/src/commands/Minion/skills.ts
@@ -1,0 +1,12 @@
+import { KlasaMessage } from 'klasa';
+
+import { BotCommand } from '../../lib/BotCommand';
+
+export default class extends BotCommand {
+	async run(msg: KlasaMessage) {
+		return msg.channel.send(
+			`The current list of skills include: Agility, Cooking, Fishing, Mining, Smithing, Woodcutting, Firemaking, Runecrafting\n
+If you'd like to see the xp/hr charts visit discord.gg/ob and look in #faq`
+		);
+	}
+}

--- a/src/lib/buyables.ts
+++ b/src/lib/buyables.ts
@@ -148,6 +148,15 @@ const Buyables: Buyable[] = [
 		},
 		qpRequired: 0,
 		gpCost: 10_000 * 5
+	},
+	{
+		name: "Iban's staff",
+		aliases: ['iban'],
+		outputItems: {
+			[itemID("Iban's staff")]: 1
+		},
+		qpRequired: 30,
+		gpCost: 250_000
 	}
 ];
 

--- a/src/lib/buyables.ts
+++ b/src/lib/buyables.ts
@@ -157,6 +157,15 @@ const Buyables: Buyable[] = [
 		},
 		qpRequired: 30,
 		gpCost: 250_000
+	},
+	{
+		name: 'Barrelchest anchor',
+		aliases: ['anchor'],
+		outputItems: {
+			[itemID('Barrelchest anchor')]: 1
+		},
+		qpRequired: 30,
+		gpCost: 2_000_000
 	}
 ];
 

--- a/src/lib/killableMonsters.ts
+++ b/src/lib/killableMonsters.ts
@@ -43,8 +43,8 @@ const killableMonsters: KillableMonster[] = [
 		notifyDrops: resolveItems([]),
 		qpRequired: 0,
 		itemInBankBoosts: {
-			[itemID('Barrows gloves')]: 5,
-			[itemID("Iban's staff")]: 2
+			[itemID('Barrows gloves')]: 2,
+			[itemID("Iban's staff")]: 5
 		}
 	},
 	{
@@ -274,7 +274,7 @@ const killableMonsters: KillableMonster[] = [
 		notifyDrops: resolveItems(["Pet kree'arra", 'Curved bone']),
 		qpRequired: 75,
 		itemInBankBoosts: {
-			[itemID('Ranger boots')]: 5
+			[itemID('Armadyl crossbow')]: 5
 		}
 	},
 	{
@@ -400,7 +400,6 @@ const killableMonsters: KillableMonster[] = [
 		]),
 		qpRequired: 0,
 		itemInBankBoosts: {
-			[itemID('Bandos godsword')]: 3,
 			[itemID('Dragon warhammer')]: 3
 		}
 	},
@@ -436,7 +435,10 @@ const killableMonsters: KillableMonster[] = [
 		wildy: true,
 		canBeKilled: true,
 		difficultyRating: 8,
-		itemsRequired: resolveItems(["Black d'hide body", "Black d'hide chaps"]),
+		itemsRequired: resolveItems([
+			["Black d'hide body", "Karil's leathertop"],
+			["Black d'hide chaps", "Karil's leatherskirt"]
+		]),
 		notifyDrops: resolveItems(['Pet chaos elemental']),
 		qpRequired: 0,
 		itemInBankBoosts: {
@@ -492,8 +494,18 @@ const killableMonsters: KillableMonster[] = [
 		itemsRequired: resolveItems([
 			'Anti-dragon shield',
 			['Armadyl crossbow', 'Rune crossbow'],
-			["Black d'hide body", "Black d'hide body (g)", "Black d'hide body (t)"],
-			["Black d'hide chaps", "Black d'hide chaps (g)", "Black d'hide chaps (t)"]
+			[
+				"Black d'hide body",
+				"Black d'hide body (g)",
+				"Black d'hide body (t)",
+				"Karil's leathertop"
+			],
+			[
+				"Black d'hide chaps",
+				"Black d'hide chaps (g)",
+				"Black d'hide chaps (t)",
+				"Karil's leatherskirt"
+			]
 		]),
 		notifyDrops: resolveItems(['Dragon pickaxe', 'Prince black dragon', 'Draconic visage']),
 		qpRequired: 0,
@@ -551,7 +563,11 @@ const killableMonsters: KillableMonster[] = [
 		wildy: false,
 		canBeKilled: true,
 		difficultyRating: 7,
-		itemsRequired: resolveItems(['Bandos godsword', "Verac's plateskirt", "Black d'hide body"]),
+		itemsRequired: resolveItems([
+			'Barrelchest anchor',
+			"Verac's plateskirt",
+			["Black d'hide body", "Karil's leathertop"]
+		]),
 		notifyDrops: resolveItems(['Jar of sand', 'Kalphite princess']),
 		qpRequired: 0,
 		itemInBankBoosts: {

--- a/src/lib/killableMonsters.ts
+++ b/src/lib/killableMonsters.ts
@@ -136,11 +136,17 @@ const killableMonsters: KillableMonster[] = [
 		wildy: false,
 		canBeKilled: true,
 		difficultyRating: 7,
-		itemsRequired: resolveItems(['Bandos chestplate', 'Bandos tassets', 'Zamorakian spear']),
+		itemsRequired: resolveItems([
+			["Torag's platebody", "Dharok's platebody"],
+			["Torag's platelegs", "Dharok's platelegs"],
+			'Zamorakian spear'
+		]),
 		notifyDrops: resolveItems(['Hellpuppy', 'Jar of souls']),
 		qpRequired: 0,
 		itemInBankBoosts: {
-			[itemID('Spectral spirit shield')]: 10
+			[itemID('Spectral spirit shield')]: 10,
+			[itemID('Bandos chestplate')]: 5,
+			[itemID('Bandos tassets')]: 5
 		}
 	},
 	{

--- a/src/lib/killableMonsters.ts
+++ b/src/lib/killableMonsters.ts
@@ -43,7 +43,8 @@ const killableMonsters: KillableMonster[] = [
 		notifyDrops: resolveItems([]),
 		qpRequired: 0,
 		itemInBankBoosts: {
-			[itemID('Barrows gloves')]: 5
+			[itemID('Barrows gloves')]: 5,
+			[itemID("Iban's staff")]: 2
 		}
 	},
 	{

--- a/src/lib/killableMonsters.ts
+++ b/src/lib/killableMonsters.ts
@@ -365,8 +365,8 @@ const killableMonsters: KillableMonster[] = [
 		notifyDrops: resolveItems(['Callisto cub', 'Curved bone', 'Tyrannical ring']),
 		qpRequired: 0,
 		itemInBankBoosts: {
-			[itemID('Proselyte hauberk')]: 2,
-			[itemID('Proselyte cuisse')]: 2
+			[itemID('Barrows gloves')]: 2,
+			[itemID('Berserker ring')]: 2
 		}
 	},
 	{

--- a/src/lib/killableMonsters.ts
+++ b/src/lib/killableMonsters.ts
@@ -41,7 +41,10 @@ const killableMonsters: KillableMonster[] = [
 		difficultyRating: 4,
 		itemsRequired: resolveItems([]),
 		notifyDrops: resolveItems([]),
-		qpRequired: 0
+		qpRequired: 0,
+		itemInBankBoosts: {
+			[itemID('Barrows gloves')]: 5
+		}
 	},
 	{
 		id: Monsters.DagannothPrime.id,
@@ -62,7 +65,13 @@ const killableMonsters: KillableMonster[] = [
 			['Armadyl chainskirt', "Karil's leatherskirt"]
 		]),
 		notifyDrops: resolveItems(['Pet dagannoth prime']),
-		qpRequired: 0
+		qpRequired: 0,
+		itemInBankBoosts: {
+			[itemID('Armadyl chestplate')]: 2,
+			[itemID('Armadyl chainskirt')]: 2,
+			[itemID('Bandos chestplate')]: 2,
+			[itemID('Bandos tassets')]: 2
+		}
 	},
 	{
 		id: Monsters.DagannothRex.id,
@@ -83,7 +92,11 @@ const killableMonsters: KillableMonster[] = [
 			['Bandos tassets', "Torag's platelegs"]
 		]),
 		notifyDrops: resolveItems(['Pet dagannoth rex']),
-		qpRequired: 0
+		qpRequired: 0,
+		itemInBankBoosts: {
+			[itemID('Occult necklace')]: 5,
+			[itemID("Iban's staff")]: 5
+		}
 	},
 	{
 		id: Monsters.DagannothSupreme.id,
@@ -104,7 +117,14 @@ const killableMonsters: KillableMonster[] = [
 			['Bandos tassets', "Torag's platelegs"]
 		]),
 		notifyDrops: resolveItems(['Pet dagannoth supreme']),
-		qpRequired: 0
+		qpRequired: 0,
+		itemInBankBoosts: {
+			[itemID('Armadyl chestplate')]: 2,
+			[itemID('Armadyl chainskirt')]: 2,
+			[itemID('Bandos chestplate')]: 2,
+			[itemID('Bandos tassets')]: 2,
+			[itemID('Saradomin godsword')]: 2
+		}
 	},
 	{
 		id: Monsters.Cerberus.id,
@@ -118,7 +138,10 @@ const killableMonsters: KillableMonster[] = [
 		difficultyRating: 7,
 		itemsRequired: resolveItems(['Bandos chestplate', 'Bandos tassets', 'Zamorakian spear']),
 		notifyDrops: resolveItems(['Hellpuppy', 'Jar of souls']),
-		qpRequired: 0
+		qpRequired: 0,
+		itemInBankBoosts: {
+			[itemID('Spectral spirit shield')]: 10
+		}
 	},
 	{
 		id: Monsters.GiantMole.id,
@@ -137,7 +160,11 @@ const killableMonsters: KillableMonster[] = [
 			"Dharok's greataxe"
 		]),
 		notifyDrops: resolveItems(['Baby mole', 'Curved bone']),
-		qpRequired: 0
+		qpRequired: 0,
+		itemInBankBoosts: {
+			[itemID('Barrows gloves')]: 5,
+			[itemID('Berserker ring')]: 5
+		}
 	},
 	{
 		id: Monsters.Vorkath.id,
@@ -151,7 +178,10 @@ const killableMonsters: KillableMonster[] = [
 		difficultyRating: 8,
 		itemsRequired: resolveItems(['Armadyl chestplate', 'Armadyl chainskirt']),
 		notifyDrops: resolveItems(['Vorki', 'Jar of decay', 'Draconic visage', 'Skeletal visage']),
-		qpRequired: 205
+		qpRequired: 205,
+		itemInBankBoosts: {
+			[itemID('Dragon warhammer')]: 10
+		}
 	},
 	{
 		id: Monsters.Zulrah.id,
@@ -175,7 +205,12 @@ const killableMonsters: KillableMonster[] = [
 			'Jar of swamp',
 			'Pet snakeling'
 		]),
-		qpRequired: 75
+		qpRequired: 75,
+		itemInBankBoosts: {
+			[itemID('Barrows gloves')]: 5,
+			[itemID('Ranger boots')]: 5,
+			[itemID("Iban's staff")]: 2
+		}
 	},
 	{
 		id: Monsters.GeneralGraardor.id,
@@ -189,7 +224,7 @@ const killableMonsters: KillableMonster[] = [
 		difficultyRating: 7,
 		itemsRequired: resolveItems([]),
 		notifyDrops: resolveItems(['Pet general graardor', 'Curved bone']),
-		qpRequired: 0,
+		qpRequired: 75,
 		itemInBankBoosts: {
 			[itemID('Dragon warhammer')]: 10
 		}
@@ -209,7 +244,11 @@ const killableMonsters: KillableMonster[] = [
 			["Karil's leatherskirt", 'Armadyl chainskirt']
 		]),
 		notifyDrops: resolveItems(['Pet zilyana']),
-		qpRequired: 0
+		qpRequired: 75,
+		itemInBankBoosts: {
+			[itemID('Ranger boots')]: 5,
+			[itemID('Armadyl crossbow')]: 5
+		}
 	},
 	{
 		id: Monsters.Kreearra.id,
@@ -226,7 +265,10 @@ const killableMonsters: KillableMonster[] = [
 			["Karil's leatherskirt", 'Armadyl chainskirt']
 		]),
 		notifyDrops: resolveItems(["Pet kree'arra", 'Curved bone']),
-		qpRequired: 0
+		qpRequired: 75,
+		itemInBankBoosts: {
+			[itemID('Ranger boots')]: 5
+		}
 	},
 	{
 		id: Monsters.KrilTsutsaroth.id,
@@ -243,7 +285,7 @@ const killableMonsters: KillableMonster[] = [
 			["Karil's leatherskirt", 'Armadyl chainskirt']
 		]),
 		notifyDrops: resolveItems(["Pet k'ril tsutsaroth"]),
-		qpRequired: 0,
+		qpRequired: 75,
 		itemInBankBoosts: {
 			[itemID('Dragon warhammer')]: 10
 		}
@@ -321,7 +363,11 @@ const killableMonsters: KillableMonster[] = [
 			"Verac's flail"
 		]),
 		notifyDrops: resolveItems(['Callisto cub', 'Curved bone', 'Tyrannical ring']),
-		qpRequired: 0
+		qpRequired: 0,
+		itemInBankBoosts: {
+			[itemID('Proselyte hauberk')]: 2,
+			[itemID('Proselyte cuisse')]: 2
+		}
 	},
 	{
 		id: Monsters.Vetion.id,
@@ -345,7 +391,11 @@ const killableMonsters: KillableMonster[] = [
 			'Curved bone',
 			'Ring of the gods'
 		]),
-		qpRequired: 0
+		qpRequired: 0,
+		itemInBankBoosts: {
+			[itemID('Bandos godsword')]: 3,
+			[itemID('Dragon warhammer')]: 3
+		}
 	},
 	{
 		id: Monsters.Venenatis.id,
@@ -364,7 +414,10 @@ const killableMonsters: KillableMonster[] = [
 			"Verac's flail"
 		]),
 		notifyDrops: resolveItems(['Treasonous ring', 'Venenatis spiderling', 'Curved bone']),
-		qpRequired: 0
+		qpRequired: 0,
+		itemInBankBoosts: {
+			[itemID('Barrows gloves')]: 3
+		}
 	},
 	{
 		id: Monsters.ChaosElemental.id,
@@ -376,9 +429,13 @@ const killableMonsters: KillableMonster[] = [
 		wildy: true,
 		canBeKilled: true,
 		difficultyRating: 8,
-		itemsRequired: resolveItems([]),
+		itemsRequired: resolveItems(["Black d'hide body", "Black d'hide chaps"]),
 		notifyDrops: resolveItems(['Pet chaos elemental']),
-		qpRequired: 0
+		qpRequired: 0,
+		itemInBankBoosts: {
+			[itemID('Archers ring')]: 3,
+			[itemID('Barrows gloves')]: 3
+		}
 	},
 	{
 		id: Monsters.ChaosFanatic.id,
@@ -392,7 +449,11 @@ const killableMonsters: KillableMonster[] = [
 		difficultyRating: 6,
 		itemsRequired: resolveItems([]),
 		notifyDrops: resolveItems(['Pet chaos elemental']),
-		qpRequired: 0
+		qpRequired: 0,
+		itemInBankBoosts: {
+			[itemID("Karil's leathertop")]: 3,
+			[itemID("Karil's leatherskirt")]: 3
+		}
 	},
 	{
 		id: Monsters.CrazyArchaeologist.id,
@@ -406,7 +467,10 @@ const killableMonsters: KillableMonster[] = [
 		difficultyRating: 6,
 		itemsRequired: resolveItems([]),
 		notifyDrops: resolveItems([]),
-		qpRequired: 0
+		qpRequired: 0,
+		itemInBankBoosts: {
+			[itemID('Occult necklace')]: 10
+		}
 	},
 	{
 		id: Monsters.KingBlackDragon.id,
@@ -421,8 +485,8 @@ const killableMonsters: KillableMonster[] = [
 		itemsRequired: resolveItems([
 			'Anti-dragon shield',
 			['Armadyl crossbow', 'Rune crossbow'],
-			"Black d'hide body",
-			"Black d'hide chaps"
+			["Black d'hide body", "Black d'hide body (g)", "Black d'hide body (t)"],
+			["Black d'hide chaps", "Black d'hide chaps (g)", "Black d'hide chaps (t)"]
 		]),
 		notifyDrops: resolveItems(['Dragon pickaxe', 'Prince black dragon', 'Draconic visage']),
 		qpRequired: 0,
@@ -442,7 +506,10 @@ const killableMonsters: KillableMonster[] = [
 		difficultyRating: 8,
 		itemsRequired: resolveItems([]),
 		notifyDrops: resolveItems(["Scorpia's offspring"]),
-		qpRequired: 0
+		qpRequired: 0,
+		itemInBankBoosts: {
+			[itemID('Occult necklace')]: 10
+		}
 	},
 	{
 		id: Monsters.CorporealBeast.id,
@@ -477,7 +544,7 @@ const killableMonsters: KillableMonster[] = [
 		wildy: false,
 		canBeKilled: true,
 		difficultyRating: 7,
-		itemsRequired: resolveItems([]),
+		itemsRequired: resolveItems(['Bandos godsword', "Verac's plateskirt", "Black d'hide body"]),
 		notifyDrops: resolveItems(['Jar of sand', 'Kalphite princess']),
 		qpRequired: 0,
 		itemInBankBoosts: {
@@ -494,9 +561,12 @@ const killableMonsters: KillableMonster[] = [
 		wildy: false,
 		canBeKilled: true,
 		difficultyRating: 6,
-		itemsRequired: resolveItems([["Karil's crossbow", 'Rune crossbow']]),
-		notifyDrops: resolveItems(['Dragon warhammer', 'Curved bone', 'Armadyl crossbow']),
-		qpRequired: 30
+		itemsRequired: resolveItems([["Karil's crossbow", 'Rune crossbow', 'Armadyl crossbow']]),
+		notifyDrops: resolveItems(['Dragon warhammer', 'Curved bone']),
+		qpRequired: 30,
+		itemInBankBoosts: {
+			[itemID('Ring of the gods')]: 3
+		}
 	},
 	{
 		id: Monsters.Lizardman.id,
@@ -608,7 +678,10 @@ const killableMonsters: KillableMonster[] = [
 		difficultyRating: 0,
 		itemsRequired: resolveItems(['Anti-dragon shield']),
 		notifyDrops: resolveItems([]),
-		qpRequired: 0
+		qpRequired: 0,
+		itemInBankBoosts: {
+			[itemID('Zamorakian spear')]: 10
+		}
 	},
 	{
 		id: Monsters.Ankou.id,

--- a/src/monitors/rareRoles.ts
+++ b/src/monitors/rareRoles.ts
@@ -1,6 +1,7 @@
 import { Monitor, MonitorStore, KlasaMessage } from 'klasa';
+import { TextChannel } from 'discord.js';
 
-import { SupportServer, Emoji } from '../lib/constants';
+import { SupportServer, Emoji, Channel } from '../lib/constants';
 import { roll } from '../lib/util';
 
 // The actual rates are these numbers divided by 10.
@@ -42,6 +43,12 @@ export default class extends Monitor {
 				}
 				msg.member?.roles.add(roleID);
 				msg.react(Emoji.Gift);
+
+				const channel = this.client.channels.get(Channel.Notifications);
+
+				(channel as TextChannel).send(
+					`${Emoji.Fireworks} **${msg.author.username}** just received the **${name} role. `
+				);
 				break;
 			}
 		}


### PR DESCRIPTION
10% boost to clue times if youre wearing graceful
10% boost to questing times if youre wearing graceful
75qp req for all gwd bosses
\>= 90 or >= 60 for runecrafting agility boost
rare roles show up in notifications
kq requires anchor, veracs skirt, black dhide body
chaos ele requires black dhide top and bottom
+skills command which tells the person what skills are availible
fix shamans not accepting acb as a required item
cerb now requires torags/dharoks instead of bcp/tassets
kbd accepts gilded dhides as well as regular

10% boost to cerb for spectral spirit shield
5% boost to cerb for both bcp and tassets
5% boost to barrows for barrows gloves
2% boost to barrows for ibans staff
5% boost to rex for both occult necklace and ibans staff
2% boost to prime for all arma chest/legs, bcp/tassets
2% boost to supreme for all arma chest/legs, bcp/tassets, sgs
5% boost to mole for both barrows gloves and berserker ring
5% boost to zulrah for both barrows gloves and ranger boots
2% boost to zulrah for iban's staff
5% boost to sara for both ranger boots and acb
5% boost to arma for ranger boots
2% boost to callisto for both barrows gloves and zerker ring
3% boost to vetion for dwh
3% boost to venenatis for barrows gloves
3% boost to chaos ele for both archers ring and barrows gloves
3% boost to chaos fanatic for both karils top and bottom
10% boost to crazy arch for occult necklace
10% boost to scorpia for occult necklace
3% boost to shamans for ring of the gods
10% boost to blue dragons for zamorakian spear