### PR TITLE
Minion icons & remove easter event

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,4 +6,4 @@
 
 -   _List of changes here_
 
-[] I have tested all my changes thoroughly.
+-   [] I have tested all my changes thoroughly.

--- a/src/commands/Minion/daily.ts
+++ b/src/commands/Minion/daily.ts
@@ -26,7 +26,6 @@ import { isWeekend, formatDuration, roll, stringMatches } from '../../lib/util';
 import { UserSettings } from '../../lib/settings/types/UserSettings';
 import { ClientSettings } from '../../lib/settings/types/ClientSettings';
 import dailyRoll from '../../lib/dailyTable';
-import itemID from '../../lib/util/itemID';
 
 const options = {
 	max: 1,
@@ -166,13 +165,6 @@ export default class DailyCommand extends BotCommand {
 				ClientSettings.EconomyStats.DailiesAmount,
 				Math.floor(dailiesAmount + Math.round(dividedAmount * 100) / 100)
 			);
-		}
-
-		const bunnyEarsID = itemID('Bunny ears');
-		const numOwned = msg.author.numOfItemsOwned(bunnyEarsID);
-		if (numOwned === 0 && roll(3)) {
-			loot[bunnyEarsID] = 1;
-			dmStr += `${Emoji.EasterEgg} **You've received a pair of Bunny Ears for Easter!**`;
 		}
 
 		await user.addItemsToBank(loot, true);

--- a/src/commands/Minion/leaderboard.ts
+++ b/src/commands/Minion/leaderboard.ts
@@ -115,7 +115,7 @@ export default class extends Command {
 	public constructor(store: CommandStore, file: string[], directory: string) {
 		super(store, file, directory, {
 			description: 'Shows the people with the most virtual GP.',
-			usage: '[pets|gp|petrecords|kc|cl|qp|skills] [name:...string]',
+			usage: '[pets|gp|petrecords|kc|cl|qp|skills|sacrifice] [name:...string]',
 			usageDelim: ' ',
 			subcommands: true,
 			aliases: ['lb'],
@@ -192,6 +192,31 @@ export default class extends Command {
 						.join('\n')
 				),
 			'GP Leaderboard'
+		);
+	}
+
+	async sacrifice(msg: KlasaMessage) {
+		const list: { id: string; amount: number }[] = (
+			await this.query(
+				`SELECT "id", "sacrificedValue" FROM users WHERE "sacrificedValue" > 0 ORDER BY "sacrificedValue" DESC LIMIT 2000;`
+			)
+		).map((res: any) => ({ ...res, amount: parseInt(res.sacrificedValue) }));
+
+		this.doMenu(
+			msg,
+			util
+				.chunk(list, 10)
+				.map(subList =>
+					subList
+						.map(
+							({ id, amount }) =>
+								`**${this.getUsername(
+									id
+								)}** sacrificed ${amount.toLocaleString()} GP `
+						)
+						.join('\n')
+				),
+			'Sacrifice Leaderboard'
 		);
 	}
 

--- a/src/commands/Minion/sacrifice.ts
+++ b/src/commands/Minion/sacrifice.ts
@@ -6,6 +6,7 @@ import { UserSettings } from '../../lib/settings/types/UserSettings';
 import itemIsTradeable from '../../lib/util/itemIsTradeable';
 import getOSItem from '../../lib/util/getOSItem';
 import minionIcons from '../../lib/minions/data/minionIcons';
+import { Events } from '../../lib/constants';
 
 const options = {
 	max: 1,
@@ -88,6 +89,10 @@ export default class extends BotCommand {
 				if (currentIcon === icon.emoji) break;
 				await msg.author.settings.update(UserSettings.Minion.Icon, icon.emoji);
 				str += `\n\nYou have now unlocked the **${icon.name}** minion icon!`;
+				this.client.emit(
+					Events.ServerNotification,
+					`**${msg.author.username}** just unlocked the ${icon.emoji} icon for their minion.`
+				);
 				break;
 			}
 		}

--- a/src/commands/Minion/sacrifice.ts
+++ b/src/commands/Minion/sacrifice.ts
@@ -1,0 +1,103 @@
+import { KlasaMessage, CommandStore } from 'klasa';
+import { Util } from 'oldschooljs';
+
+import { BotCommand } from '../../lib/BotCommand';
+import { UserSettings } from '../../lib/settings/types/UserSettings';
+import itemIsTradeable from '../../lib/util/itemIsTradeable';
+import getOSItem from '../../lib/util/getOSItem';
+import minionIcons from '../../lib/minions/data/minionIcons';
+
+const options = {
+	max: 1,
+	time: 10000,
+	errors: ['time']
+};
+
+export default class extends BotCommand {
+	public constructor(store: CommandStore, file: string[], directory: string) {
+		super(store, file, directory, {
+			cooldown: 1,
+			usage: '[quantity:int{1}] [itemname:...string]',
+			usageDelim: ' ',
+			oneAtTime: true
+		});
+	}
+
+	async run(msg: KlasaMessage, [quantity, itemName]: [number | undefined, string]) {
+		if (!itemName) {
+			return msg.send(
+				`Your current sacrificed amount is: ${msg.author.settings
+					.get(UserSettings.SacrificedValue)
+					.toLocaleString()}. You can see the icons you can unlock here: <https://www.oldschool.gg/oldschoolbot/minions?Minion%20Icons>`
+			);
+		}
+
+		const osItem = getOSItem(itemName);
+
+		if (!itemIsTradeable(osItem.id)) {
+			throw `That item isn't tradeable.`;
+		}
+
+		const numItemsHas = await msg.author.numberOfItemInBank(osItem.id);
+		if (numItemsHas === 0) throw `You don't have any of this item.`;
+
+		if (!quantity) {
+			quantity = numItemsHas;
+		}
+
+		const priceOfItem = await this.client.fetchItemPrice(osItem.id);
+		const totalPrice = priceOfItem * quantity;
+
+		if (quantity > numItemsHas) {
+			throw `You dont have ${quantity}x ${osItem.name}.`;
+		}
+
+		if (!msg.flagArgs.confirm && !msg.flagArgs.cf) {
+			const sellMsg = await msg.channel.send(
+				`${msg.author}, say \`confirm\` to sacrifice ${quantity} ${
+					osItem.name
+				}, this will add ${totalPrice.toLocaleString()} (${Util.toKMB(
+					totalPrice
+				)}) to your sacrificed amount.`
+			);
+
+			try {
+				await msg.channel.awaitMessages(
+					_msg =>
+						_msg.author.id === msg.author.id &&
+						_msg.content.toLowerCase() === 'confirm',
+					options
+				);
+			} catch (err) {
+				return sellMsg.edit(`Cancelling sacrifice of ${quantity}x ${osItem.name}.`);
+			}
+		}
+
+		const newValue = msg.author.settings.get(UserSettings.SacrificedValue) + totalPrice;
+
+		await msg.author.settings.update(UserSettings.SacrificedValue, newValue);
+		await msg.author.removeItemFromBank(osItem.id, quantity);
+
+		msg.author.log(`sacrificed Quantity[${quantity}] ItemID[${osItem.id}] for ${totalPrice}`);
+
+		let str = '';
+		const currentIcon = msg.author.settings.get(UserSettings.Minion.Icon);
+		for (const icon of minionIcons) {
+			if (newValue < icon.valueRequired) continue;
+			if (newValue >= icon.valueRequired) {
+				if (currentIcon === icon.emoji) break;
+				await msg.author.settings.update(UserSettings.Minion.Icon, icon.emoji);
+				str += `\n\nYou have now unlocked the **${icon.name}** minion icon!`;
+				break;
+			}
+		}
+
+		return msg.send(
+			`You sacrificed ${quantity}x ${
+				osItem.name
+			}, with a value of ${totalPrice.toLocaleString()}gp (${Util.toKMB(
+				totalPrice
+			)}). Your total amount sacrificed is now: ${newValue.toLocaleString()}. ${str}`
+		);
+	}
+}

--- a/src/extendables/UserExtendables.ts
+++ b/src/extendables/UserExtendables.ts
@@ -286,9 +286,12 @@ export default class extends Extendable {
 	public get minionName(this: User): string {
 		const name = this.settings.get(UserSettings.Minion.Name);
 		const prefix = this.settings.get(UserSettings.Minion.Ironman) ? Emoji.Ironman : '';
+
+		const icon = this.settings.get(UserSettings.Minion.Icon) ?? Emoji.Minion;
+
 		return name
-			? `${prefix} ${Emoji.Minion} **${Util.escapeMarkdown(name)}**`
-			: `${prefix} ${Emoji.Minion} Your minion`;
+			? `${prefix} ${icon} **${Util.escapeMarkdown(name)}**`
+			: `${prefix} ${icon} Your minion`;
 	}
 
 	public get hasMinion(this: User) {

--- a/src/lib/minions/data/minionIcons.ts
+++ b/src/lib/minions/data/minionIcons.ts
@@ -1,0 +1,29 @@
+const minionIcons = [
+	{
+		emoji: '<:whiteMinion:673561609913892899>',
+		valueRequired: 10_000_000_000,
+		name: '3rd age'
+	},
+	{
+		emoji: '<:sapphireMinion:673561609834070047>',
+		valueRequired: 5_000_000_000,
+		name: 'Sapphire'
+	},
+	{
+		emoji: '<:amethystMinion:673561610228465664>',
+		valueRequired: 1_000_000_000,
+		name: 'Amethyst'
+	},
+	{
+		emoji: '<:emeraldMinion:673561610366746635>',
+		valueRequired: 500_000_000,
+		name: 'Emerald'
+	},
+	{
+		emoji: '<:yellowMinion:673561629115416616>',
+		valueRequired: 100_000_000,
+		name: 'Yellow'
+	}
+];
+
+export default minionIcons;

--- a/src/lib/settings/schemas/UserSchema.ts
+++ b/src/lib/settings/schemas/UserSchema.ts
@@ -13,6 +13,7 @@ Client.defaultUserSchema
 	.add('badges', 'integer', { array: true, default: [] })
 	.add('bitfield', 'integer', { array: true, default: [] })
 	.add('lastDailyTimestamp', 'integer', { default: 1 })
+	.add('sacrificedValue', 'integer', { default: 0, maximum: 100_000_000_000, minimum: 0 })
 	.add('bank', 'any', { default: {} })
 	.add('collectionLogBank', 'any', { default: {} })
 	.add('monsterScores', 'any', { default: {} })
@@ -24,6 +25,7 @@ Client.defaultUserSchema
 			.add('hasBought', 'boolean', { default: false })
 			.add('dailyDuration', 'integer', { default: 0 })
 			.add('ironman', 'boolean', { default: false })
+			.add('icon', 'string', { default: null })
 	)
 	.add('stats', (folder: SchemaFolder) =>
 		folder

--- a/src/lib/settings/types/UserSettings.ts
+++ b/src/lib/settings/types/UserSettings.ts
@@ -23,6 +23,7 @@ export namespace UserSettings {
 	export const Badges = T<readonly number[]>('badges');
 	export const RSN = T<string>('RSN');
 	export const TotalCommandsUsed = T<number>('totalCommandsUsed');
+	export const SacrificedValue = T<number>('sacrificedValue');
 
 	export namespace Stats {
 		export const Deaths = T<number>('stats.deaths');
@@ -36,10 +37,10 @@ export namespace UserSettings {
 
 	export namespace Minion {
 		export const Name = T<string>('minion.name');
-
 		export const HasBought = T<boolean>('minion.hasBought');
 		export const DailyDuration = T<number>('minion.dailyDuration');
 		export const Ironman = T<boolean>('minion.ironman');
+		export const Icon = T<string | null>('minion.icon');
 	}
 
 	export namespace Skills {

--- a/src/tasks/minions/clueActivity.ts
+++ b/src/tasks/minions/clueActivity.ts
@@ -2,20 +2,8 @@ import { Task } from 'klasa';
 
 import clueTiers from '../../lib/minions/data/clueTiers';
 import { ClueActivityTaskOptions } from '../../lib/types/minions';
-import { Events, Emoji } from '../../lib/constants';
+import { Events } from '../../lib/constants';
 import { channelIsSendable } from '../../lib/util/channelIsSendable';
-import itemID from '../../lib/util/itemID';
-import { roll } from 'oldschooljs/dist/util/util';
-import { randomItemFromArray } from '../../lib/util';
-
-const easterEggMessages = [
-	'While on an adventure finishing this clue, {name} stumbled upon an Easter Bunny who gave them an Easter Egg!',
-	'{name} found an Easter Egg in the gardens of Falador while completing the clue scroll!',
-	'The Easter Bunny gave {name} an Easter Egg while they were doing the clue scroll!',
-	'{name} found an Easter Egg under a fountain in Lumbridge while completing the clue scroll!',
-	'{name} found an Easter Egg sitting on a path while completing the clue scroll!',
-	'{name} found an Easter Egg in the Tree Gnome Village maze completing the clue scroll!'
-];
 
 export default class extends Task {
 	async run({ clueID, userID, channelID, quantity }: ClueActivityTaskOptions) {
@@ -29,32 +17,13 @@ export default class extends Task {
 			return;
 		}
 
-		let str = `${user}, ${user.minionName} finished completing ${quantity} ${
+		const str = `${user}, ${user.minionName} finished completing ${quantity} ${
 			clueTier.name
 		} clues. ${user.minionName} carefully places the reward casket${
 			quantity > 1 ? 's' : ''
 		} in your bank. You can open this casket using \`+open ${clueTier.name}\``;
 
 		const loot = { [clueTier.id]: quantity };
-		const easterEggID = itemID('Easter egg');
-
-		const eggChances: { [key: number]: number } = {
-			19836: 3,
-			20543: 4,
-			20544: 5,
-			20545: 6,
-			20546: 7,
-			23245: 8
-		};
-
-		if (roll(eggChances[clueTier.id])) {
-			loot[easterEggID] = 1;
-			str += `\n\n${Emoji.EasterEgg} **${randomItemFromArray(easterEggMessages).replace(
-				'{name}',
-				user.minionName
-			)}**`;
-		}
-
 		await user.addItemsToBank(loot, true);
 
 		this.client.emit(


### PR DESCRIPTION
### Description:

-  Adds minion icons unlocked by sacrificing items (as an item sink), and removes the easter event.

### Changes:

- Adds new `sacrificedValue` setting and `minion.icon` setting.
- Adds `+sacrifice` command.
- Removes getting easter eggs from clues.
- Adds notification when unlocking a new minion icon.
- Removes getting bunny ears from dailies.

- [x] I have tested all my changes thoroughly.
