### PR TITLE
fixed smithing time

### DIFF
--- a/src/commands/Minion/smith.ts
+++ b/src/commands/Minion/smith.ts
@@ -76,7 +76,7 @@ export default class extends BotCommand {
 
 		// If no quantity provided, set it to the max.
 		if (quantity === null) {
-			quantity = Math.floor((Time.Minute * 30) / timeToSmithSingleBar);
+			quantity = Math.floor(msg.author.maxTripLength / timeToSmithSingleBar);
 		}
 
 		await msg.author.settings.sync(true);

--- a/src/lib/killableMonsters.ts
+++ b/src/lib/killableMonsters.ts
@@ -69,9 +69,7 @@ const killableMonsters: KillableMonster[] = [
 		qpRequired: 0,
 		itemInBankBoosts: {
 			[itemID('Armadyl chestplate')]: 2,
-			[itemID('Armadyl chainskirt')]: 2,
-			[itemID('Bandos chestplate')]: 2,
-			[itemID('Bandos tassets')]: 2
+			[itemID('Armadyl chainskirt')]: 2
 		}
 	},
 	{
@@ -120,8 +118,6 @@ const killableMonsters: KillableMonster[] = [
 		notifyDrops: resolveItems(['Pet dagannoth supreme']),
 		qpRequired: 0,
 		itemInBankBoosts: {
-			[itemID('Armadyl chestplate')]: 2,
-			[itemID('Armadyl chainskirt')]: 2,
 			[itemID('Bandos chestplate')]: 2,
 			[itemID('Bandos tassets')]: 2,
 			[itemID('Saradomin godsword')]: 2


### PR DESCRIPTION
### Description:

-   changed smithing time and removed extra boosts 

### Changes:

-   changed the smithing time to use msg.author.maxTripLength
-   removed armadyl boost from dagannoth supreme
-   removed bandos boost from dagannoth prime

-   [!] I have tested all my changes thoroughly.
