### PR TITLE
Few fixes/additions

### DIFF
--- a/src/commands/Minion/chop.ts
+++ b/src/commands/Minion/chop.ts
@@ -5,7 +5,8 @@ import {
 	stringMatches,
 	formatDuration,
 	rand,
-	itemNameFromID
+	itemNameFromID,
+	isWeekend
 } from '../../lib/util';
 import { BotCommand } from '../../lib/BotCommand';
 import { Activity, Tasks } from '../../lib/constants';
@@ -103,7 +104,7 @@ export default class extends BotCommand {
 			quantity = Math.floor(msg.author.maxTripLength / timetoChop);
 		}
 
-		const duration = quantity * timetoChop;
+		let duration = quantity * timetoChop;
 
 		if (duration > msg.author.maxTripLength) {
 			throw `${msg.author.minionName} can't go on trips longer than ${formatDuration(
@@ -111,6 +112,11 @@ export default class extends BotCommand {
 			)}, try a lower quantity. The highest amount of ${
 				log.name
 			} you can chop is ${Math.floor(msg.author.maxTripLength / timetoChop)}.`;
+		}
+
+		if (isWeekend()) {
+			boosts.push(`10% for Weekend`);
+			duration *= 0.9;
 		}
 
 		const data: WoodcuttingActivityTaskOptions = {

--- a/src/commands/Minion/craft.ts
+++ b/src/commands/Minion/craft.ts
@@ -6,7 +6,8 @@ import {
 	formatDuration,
 	rand,
 	itemNameFromID,
-	removeItemFromBank
+	removeItemFromBank,
+	isWeekend
 } from '../../lib/util';
 import { SkillsEnum } from '../../lib/skilling/types';
 import { Time, Activity, Tasks } from '../../lib/constants';
@@ -93,7 +94,7 @@ export default class extends BotCommand {
 			}
 		}
 
-		const duration = quantity * timeToCraftSingleItem;
+		let duration = quantity * timeToCraftSingleItem;
 
 		if (duration > msg.author.maxTripLength) {
 			throw `${msg.author.minionName} can't go on trips longer than ${formatDuration(
@@ -116,6 +117,12 @@ export default class extends BotCommand {
 			if (!bankHasItem(userBank, id, qty * quantity)) {
 				throw `You don't have enough ${itemNameFromID(id)}.`;
 			}
+		}
+
+		const boosts = [];
+		if (isWeekend()) {
+			boosts.push(`10% for Weekend`);
+			duration *= 0.9;
 		}
 
 		const data: CraftingActivityTaskOptions = {
@@ -143,10 +150,14 @@ export default class extends BotCommand {
 		await addSubTaskToActivityTask(this.client, Tasks.SkillingTicker, data);
 
 		msg.author.incrementMinionDailyDuration(duration);
-		return msg.send(
-			`${msg.author.minionName} is now crafting ${quantity}x ${
-				Craft.name
-			}, it'll take around ${formatDuration(duration)} to finish.`
-		);
+		let response = `${msg.author.minionName} is now crafting ${quantity}x ${
+			Craft.name
+		}, it'll take around ${formatDuration(duration)} to finish.`;
+
+		if (boosts.length > 0) {
+			response += `\n\n **Boosts:** ${boosts.join(', ')}.`;
+		}
+
+		return msg.send(response);
 	}
 }

--- a/src/commands/Minion/create.ts
+++ b/src/commands/Minion/create.ts
@@ -33,7 +33,10 @@ export default class extends BotCommand {
 		itemName = itemName.toLowerCase();
 
 		const createableItem = Createables.find(item => stringMatches(item.name, itemName));
-		if (!createableItem) throw `That's not a valid item you can create.`;
+		if (!createableItem)
+			throw `That's not a valid item you can create. Valid items are: ${Createables.map(
+				item => item.name
+			).join(', ')}.`;
 
 		// Ensure they have the required skills to create the item.
 		if (

--- a/src/commands/Minion/fish.ts
+++ b/src/commands/Minion/fish.ts
@@ -6,7 +6,8 @@ import {
 	formatDuration,
 	rand,
 	itemNameFromID,
-	calcPercentOfNum
+	calcPercentOfNum,
+	isWeekend
 } from '../../lib/util';
 import Fishing from '../../lib/skilling/skills/fishing';
 import { Time, Activity, Tasks } from '../../lib/constants';
@@ -94,6 +95,12 @@ export default class extends BotCommand {
 		const tenPercent = Math.floor(calcPercentOfNum(10, duration));
 		duration += rand(-tenPercent, tenPercent);
 
+		const boosts = [];
+		if (isWeekend()) {
+			boosts.push(`10% for Weekend`);
+			duration *= 0.9;
+		}
+
 		const data: FishingActivityTaskOptions = {
 			fishID: fish.id,
 			userID: msg.author.id,
@@ -113,9 +120,13 @@ export default class extends BotCommand {
 		await addSubTaskToActivityTask(this.client, Tasks.SkillingTicker, data);
 		msg.author.incrementMinionDailyDuration(duration);
 
-		const response = `${msg.author.minionName} is now fishing ${quantity}x ${
+		let response = `${msg.author.minionName} is now fishing ${quantity}x ${
 			fish.name
 		}, it'll take around ${formatDuration(duration)} to finish.`;
+
+		if (boosts.length > 0) {
+			response += `\n\n **Boosts:** ${boosts.join(', ')}.`;
+		}
 
 		return msg.send(response);
 	}

--- a/src/commands/Minion/mclue.ts
+++ b/src/commands/Minion/mclue.ts
@@ -64,6 +64,17 @@ export default class extends BotCommand {
 			} is ${Math.floor(msg.author.maxTripLength / timeToFinish)}.`;
 		}
 
+		const currentQP = msg.author.settings.get(UserSettings.QP);
+		if (currentQP !== 0) {
+			let boostAmount = 1 - 0.25 * (currentQP / clueTier.qpBoost);
+			if (currentQP >= clueTier.qpBoost) {
+				boostAmount = 0.75;
+			}
+			const actualNumber = Math.floor((1 - boostAmount) * 100);
+			boosts.push(`${actualNumber}% boost for QP`);
+			duration *= boostAmount;
+		}
+
 		const bank = msg.author.settings.get(UserSettings.Bank);
 		const numOfScrolls = bank[clueTier.scrollID];
 

--- a/src/commands/Minion/mine.ts
+++ b/src/commands/Minion/mine.ts
@@ -6,7 +6,8 @@ import {
 	stringMatches,
 	formatDuration,
 	rand,
-	itemNameFromID
+	itemNameFromID,
+	isWeekend
 } from '../../lib/util';
 import Mining from '../../lib/skilling/skills/mining';
 import { Activity, Tasks } from '../../lib/constants';
@@ -119,7 +120,7 @@ export default class extends BotCommand {
 		if (quantity === null) {
 			quantity = Math.floor(msg.author.maxTripLength / timeToMine);
 		}
-		const duration = quantity * timeToMine;
+		let duration = quantity * timeToMine;
 
 		if (duration > msg.author.maxTripLength) {
 			throw `${msg.author.minionName} can't go on trips longer than ${formatDuration(
@@ -127,6 +128,11 @@ export default class extends BotCommand {
 			)}, try a lower quantity. The highest amount of ${
 				ore.name
 			} you can mine is ${Math.floor(msg.author.maxTripLength / timeToMine)}.`;
+		}
+
+		if (isWeekend()) {
+			boosts.push(`10% for Weekend`);
+			duration *= 0.9;
 		}
 
 		const data: MiningActivityTaskOptions = {

--- a/src/commands/Minion/skills.ts
+++ b/src/commands/Minion/skills.ts
@@ -5,7 +5,7 @@ import { BotCommand } from '../../lib/BotCommand';
 export default class extends BotCommand {
 	async run(msg: KlasaMessage) {
 		return msg.channel.send(
-			`The current list of skills include: Agility, Cooking, Fishing, Mining, Smithing, Woodcutting, Firemaking, Runecrafting\n
+			`The current list of skills include: Agility, Cooking, Crafting, Fishing, Mining, Smithing, Woodcutting, Firemaking, Runecrafting\n
 If you'd like to see the xp/hr charts visit discord.gg/ob and look in #faq`
 		);
 	}

--- a/src/commands/Minion/smith.ts
+++ b/src/commands/Minion/smith.ts
@@ -6,7 +6,8 @@ import {
 	formatDuration,
 	rand,
 	itemNameFromID,
-	removeItemFromBank
+	removeItemFromBank,
+	isWeekend
 } from '../../lib/util';
 import { SkillsEnum } from '../../lib/skilling/types';
 import { Time, Activity, Tasks, Events } from '../../lib/constants';
@@ -91,7 +92,7 @@ export default class extends BotCommand {
 			}
 		}
 
-		const duration = quantity * timeToSmithSingleBar;
+		let duration = quantity * timeToSmithSingleBar;
 
 		if (duration > msg.author.maxTripLength) {
 			throw `${msg.author.minionName} can't go on trips longer than ${formatDuration(
@@ -99,6 +100,12 @@ export default class extends BotCommand {
 			)}, try a lower quantity. The highest amount of ${
 				smithedBar.name
 			}s you can smith is ${Math.floor(msg.author.maxTripLength / timeToSmithSingleBar)}.`;
+		}
+
+		const boosts = [];
+		if (isWeekend()) {
+			boosts.push(`10% for Weekend`);
+			duration *= 0.9;
 		}
 
 		const data: SmithingActivityTaskOptions = {
@@ -131,10 +138,15 @@ export default class extends BotCommand {
 		await msg.author.settings.update(UserSettings.Bank, newBank);
 
 		msg.author.incrementMinionDailyDuration(duration);
-		return msg.send(
-			`${msg.author.minionName} is now smithing ${quantity * smithedBar.outputMultiple}x ${
-				smithedBar.name
-			}, using ${usedbars} bars, it'll take around ${formatDuration(duration)} to finish.`
-		);
+		let response = `${msg.author.minionName} is now smithing ${quantity *
+			smithedBar.outputMultiple}x ${
+			smithedBar.name
+		}, using ${usedbars} bars, it'll take around ${formatDuration(duration)} to finish.`;
+
+		if (boosts.length > 0) {
+			response += `\n\n **Boosts:** ${boosts.join(', ')}.`;
+		}
+
+		return msg.send(response);
 	}
 }

--- a/src/lib/buyables.ts
+++ b/src/lib/buyables.ts
@@ -153,10 +153,10 @@ const Buyables: Buyable[] = [
 		name: 'Huge Jug Pack',
 		aliases: ['jug of water', 'jugs of water'],
 		outputItems: {
-			[itemID('Jug of water')]: 300
+			[itemID('Jug of water')]: 1000
 		},
 		qpRequired: 0,
-		gpCost: 300 * 100
+		gpCost: 10_000
 	},
 	{
 		name: "Iban's staff",
@@ -184,6 +184,15 @@ const Buyables: Buyable[] = [
 		},
 		qpRequired: 0,
 		gpCost: 300 * 100
+	},
+	{
+		name: 'Ball of wool',
+		aliases: ['wool'],
+		outputItems: {
+			[itemID('Ball of wool')]: 1
+		},
+		qpRequired: 0,
+		gpCost: 100_000
 	}
 ];
 

--- a/src/lib/createables.ts
+++ b/src/lib/createables.ts
@@ -522,6 +522,50 @@ const Createables: Createable[] = [
 			[itemID('Hell cat ears')]: 1
 		},
 		addOutputToCollectionLog: true
+	},
+	{
+		name: 'Serpentine helm',
+		inputItems: {
+			[itemID('Serpentine helm (uncharged)')]: 1,
+			[itemID("Zulrah's scales")]: 11_000
+		},
+		outputItems: {
+			[itemID('Serpentine helm')]: 1
+		},
+		cantHaveItems: {}
+	},
+	{
+		name: 'Toxic staff of the dead',
+		inputItems: {
+			[itemID('Toxic staff (uncharged)')]: 1,
+			[itemID("Zulrah's scales")]: 11_000
+		},
+		outputItems: {
+			[itemID('Toxic staff of the dead')]: 1
+		},
+		cantHaveItems: {}
+	},
+	{
+		name: 'Magma helm',
+		inputItems: {
+			[itemID('Serpentine helm')]: 1,
+			[itemID('Magma mutagen')]: 1
+		},
+		outputItems: {
+			[itemID('Magma helm')]: 1
+		},
+		cantHaveItems: {}
+	},
+	{
+		name: 'Tanzanite helm',
+		inputItems: {
+			[itemID('Serpentine helm')]: 1,
+			[itemID('Tanzanite mutagen')]: 1
+		},
+		outputItems: {
+			[itemID('Tanzanite helm')]: 1
+		},
+		cantHaveItems: {}
 	}
 ];
 

--- a/src/lib/filterables.ts
+++ b/src/lib/filterables.ts
@@ -155,7 +155,11 @@ const skilling = resolveItems([
 	'Raw shark',
 	'Grapes',
 	'Battlestaff',
-	'Fire orb'
+	'Fire orb',
+	'Green dragon leather',
+	'Blue dragon leather',
+	'Red dragon leather',
+	'Black dragon leather'
 ]);
 
 const gear = resolveItems([

--- a/src/lib/filterables.ts
+++ b/src/lib/filterables.ts
@@ -60,6 +60,12 @@ const skilling = resolveItems([
 	'Uncut diamond',
 	'Uncut dragonstone',
 	'Uncut onyx',
+	'Sapphire',
+	'Emerald',
+	'Ruby',
+	'Diamond',
+	'Dragonstone',
+	'Onyx',
 	'Logs',
 	'Oak logs',
 	'Willow logs',
@@ -147,7 +153,9 @@ const skilling = resolveItems([
 	'Celastrus seed',
 	'Redwood tree seed',
 	'Raw shark',
-	'Grapes'
+	'Grapes',
+	'Battlestaff',
+	'Fire orb'
 ]);
 
 const gear = resolveItems([

--- a/src/lib/minions/data/clueTiers.ts
+++ b/src/lib/minions/data/clueTiers.ts
@@ -12,7 +12,8 @@ const ClueTiers: ClueTier[] = [
 		table: Beginner,
 		id: 23245,
 		scrollID: 23182,
-		timeToFinish: Time.Minute * 4.5
+		timeToFinish: Time.Minute * 4.5,
+		qpBoost: 20
 	},
 	{
 		name: 'Easy',
@@ -23,7 +24,8 @@ const ClueTiers: ClueTier[] = [
 		milestoneReward: {
 			itemReward: itemID('Large spade'),
 			scoreNeeded: 500
-		}
+		},
+		qpBoost: 40
 	},
 	{
 		name: 'Medium',
@@ -34,14 +36,16 @@ const ClueTiers: ClueTier[] = [
 		milestoneReward: {
 			itemReward: itemID('Clueless scroll'),
 			scoreNeeded: 400
-		}
+		},
+		qpBoost: 75
 	},
 	{
 		name: 'Hard',
 		table: Hard,
 		id: 20544,
 		scrollID: 2722,
-		timeToFinish: Time.Minute * 12.5
+		timeToFinish: Time.Minute * 12.5,
+		qpBoost: 150
 	},
 	{
 		name: 'Elite',
@@ -52,7 +56,8 @@ const ClueTiers: ClueTier[] = [
 		milestoneReward: {
 			itemReward: itemID('Heavy casket'),
 			scoreNeeded: 200
-		}
+		},
+		qpBoost: 200
 	},
 	{
 		name: 'Master',
@@ -63,7 +68,8 @@ const ClueTiers: ClueTier[] = [
 		milestoneReward: {
 			itemReward: itemID('Scroll sack'),
 			scoreNeeded: 100
-		}
+		},
+		qpBoost: 275
 	}
 ];
 

--- a/src/lib/minions/types.d.ts
+++ b/src/lib/minions/types.d.ts
@@ -32,4 +32,5 @@ export interface ClueTier {
 	scrollID: number;
 	timeToFinish: number;
 	milestoneReward?: ClueMilestoneReward;
+	qpBoost: number;
 }

--- a/src/lib/skilling/skills/mining.ts
+++ b/src/lib/skilling/skills/mining.ts
@@ -28,10 +28,10 @@ const ores: Ore[] = [
 	},
 	{
 		level: 15,
-		xp: 48,
+		xp: 35,
 		id: 440,
 		name: 'Iron ore',
-		respawnTime: 0.2,
+		respawnTime: -0.1,
 		petChance: 750_000
 	},
 	{
@@ -60,7 +60,7 @@ const ores: Ore[] = [
 	},
 	{
 		level: 40,
-		xp: 45,
+		xp: 65,
 		id: 444,
 		name: 'Gold ore',
 		respawnTime: 4,


### PR DESCRIPTION
### Description:

-   Random stuff fixed/added

### Changes:

-   Revert gold xp from 45 -> 65, quantity/hr from 457 -> 408, xp/hr from 20.5k -> 26.5k
-   Change iron xp from 48 -> 35, quantity/hr from 1042 -> 1456, xp/hr from 50k -> 50.9k
-   Able to buy 1 ball of wool for 100k
-   Able to put scales in serp helm, toxic staff of the dead
-   Able to create magma/tanzanite helms
-   List out all createables instead of saying 'thats not a valid item'
-   Add crafting to the +skills command
-   All skills get a 10% boost on the weekend (97-0 in #suggestions)
-   Change 300 jugs of water for 3k, to 1k jugs of water for 10k
-   Add gems/bstaves/orb to +b --skilling
-   Add boost to clue times based off users QP
    * TierQP: Beginner = 20, Easy = 40, Medium = 75, Hard = 150, Elite = 200, Master = 275
    * Total boost = 25% * (CurrentQP / TierQp)  --- capped at 25% boost

-   [✓] I have tested all my changes thoroughly.
