### PR TITLE
craft: throw if num items owned < qty

### DIFF
--- a/src/commands/Minion/craft.ts
+++ b/src/commands/Minion/craft.ts
@@ -86,8 +86,8 @@ export default class extends BotCommand {
 					continue;
 				}
 				const itemsOwned = userBank[parseInt(itemID)];
-				if (!itemsOwned) {
-					throw `You have no ${itemNameFromID(parseInt(itemID))}.`;
+				if (itemsOwned < qty) {
+					throw `You dont have enough ${itemNameFromID(parseInt(itemID))}.`;
 				}
 				quantity = Math.min(quantity, Math.floor(itemsOwned / qty));
 			}


### PR DESCRIPTION
### Description:

having > 0 but < qty of items required would still send the minion out on a trip but it would be of size 0.

### Changes:

throw if num items owned < qty

-   [x] I have tested all my changes thoroughly.
