### PR TITLE
fixes a few incorrect entries in +cl hard

### DIFF
--- a/src/lib/collectionLog.ts
+++ b/src/lib/collectionLog.ts
@@ -764,13 +764,6 @@ export const cluesHard = {
 		'Gilded plateskirt',
 		'Gilded kiteshield',
 		'Gilded sq shield',
-		'Gilded boots'
-	]),
-	'Gilded 2': resolveItems([
-		'Gilded coif',
-		"Gilded d'hide body",
-		"Gilded d'hide chaps",
-		"Gilded d'hide vambraces",
 		'Gilded 2h sword',
 		'Gilded spear',
 		'Gilded hasta'


### PR DESCRIPTION
### Description:

fixes a few incorrect entries in +cl hard

### Changes:
removes the following from the hard clue collection log
 - Gilded boots
 - Gilded coif
 - Gilded d'hide body
 - Gilded d'hide chaps
 - Gilded d'hide vambraces
