### PR TITLE
add cancel command to end minion trip immediately with no rewards

### DIFF
--- a/src/commands/Minion/cancel.ts
+++ b/src/commands/Minion/cancel.ts
@@ -1,0 +1,66 @@
+import { KlasaMessage, CommandStore } from 'klasa';
+
+import { BotCommand } from '../../lib/BotCommand';
+import getActivityOfUser from '../../lib/util/getActivityOfUser';
+import removeSubTasksFromActivityTask from '../../lib/util/removeSubTasksFromActivityTask';
+import { Tasks, Activity, Time } from '../../lib/constants';
+import { requiresMinion } from '../../lib/minions/decorators';
+
+const options = {
+	max: 1,
+	time: 10000,
+	errors: ['time']
+};
+
+export default class extends BotCommand {
+	public constructor(store: CommandStore, file: string[], directory: string) {
+		super(store, file, directory, {
+			oneAtTime: true,
+			cooldown: 180
+		});
+	}
+
+	@requiresMinion
+	async run(msg: KlasaMessage) {
+		const currentTask = getActivityOfUser(this.client, msg.author);
+
+		if (!currentTask) {
+			throw `${msg.author.minionName} isn't doing anything at the moment, so there's nothing to cancel.`;
+		}
+
+		if (currentTask.finishDate - Date.now() < Time.Minute * 1.5) {
+			throw `${msg.author.minionName} is already on their way back from the trip, returning in around a minute, no point in cancelling now!`;
+		}
+
+		if (currentTask.type === Activity.GroupMonsterKilling) {
+			throw `${msg.author.minionName} is in a group PVM trip, their team wouldn't like it if you left them!`;
+		}
+
+		const taskTicker =
+			currentTask.type === Activity.ClueCompletion
+				? Tasks.ClueTicker
+				: currentTask.type === Activity.MonsterKilling
+				? Tasks.MonsterKillingTicker
+				: Tasks.SkillingTicker;
+
+		const cancelMsg = await msg.channel.send(
+			`${msg.author} ${msg.author.minionStatus}\n Say \`confirm\` if you want to call your minion back from their trip. They'll drop all their current loot to get back as fast as they can, so you won't receive any loot from this trip if you cancel it.`
+		);
+
+		try {
+			await msg.channel.awaitMessages(
+				_msg =>
+					_msg.author.id === msg.author.id && _msg.content.toLowerCase() === 'confirm',
+				options
+			);
+		} catch (err) {
+			return cancelMsg.edit(`Halting cancelation of minion task.`);
+		}
+
+		await removeSubTasksFromActivityTask(this.client, taskTicker, [currentTask.id]);
+
+		return msg.send(
+			`${msg.author.minionName}'s trip was cancelled, and they're now available.`
+		);
+	}
+}

--- a/src/commands/Minion/minion.ts
+++ b/src/commands/Minion/minion.ts
@@ -60,7 +60,7 @@ export default class MinionCommand extends BotCommand {
 			cooldown: 1,
 			aliases: ['m'],
 			usage:
-				'[clues|k|kill|setname|buy|clue|kc|pat|stats|mine|smith|quest|qp|chop|ironman|light|fish|laps|cook|smelt|craft|bury|offer|fletch] [quantity:int{1}|name:...string] [name:...string]',
+				'[clues|k|kill|setname|buy|clue|kc|pat|stats|mine|smith|quest|qp|chop|ironman|light|fish|laps|cook|smelt|craft|bury|offer|fletch|cancel] [quantity:int{1}|name:...string] [name:...string]',
 
 			usageDelim: ' ',
 			subcommands: true
@@ -472,6 +472,15 @@ ${Emoji.QuestIcon} QP: ${msg.author.settings.get(UserSettings.QP)}
 	async quest(msg: KlasaMessage) {
 		await this.client.commands
 			.get('quest')!
+			.run(msg, [])
+			.catch(err => {
+				throw err;
+			});
+	}
+
+	async cancel(msg: KlasaMessage) {
+		await this.client.commands
+			.get('cancel')!
 			.run(msg, [])
 			.catch(err => {
 				throw err;


### PR DESCRIPTION
### Description:

Adds the `cancel` command to immediately end the users minion trip with no rewards.  The user is prompted with the current trip the minion is on and then asked to confirm the cancellation before it goes through.  
Upon confirmation the minion immediately returns from their trip with no rewards and without reimbursing any items used when the trip was originally sent out.

### Changes:

-   [x] I have tested all my changes thoroughly.
the cooldown doesnt seem to work but i put it at 180 seconds since thats reasonable to avoid abuse when spam canceling trying to look for a low rolled rng time increase. Perhaps since i am the "owner" of my test bot i dont get rate limited