### PR TITLE
create `monster` command to display trip information on any monster

### DIFF
--- a/src/commands/Minion/monster.ts
+++ b/src/commands/Minion/monster.ts
@@ -1,0 +1,111 @@
+import { CommandStore, KlasaMessage } from 'klasa';
+
+import { BotCommand } from '../../lib/BotCommand';
+import killableMonsters from '../../lib/minions/data/killableMonsters';
+import { formatDuration, isWeekend } from '../../lib/util';
+import findMonster from '../../lib/minions/functions/findMonster';
+import reducedTimeFromKC from '../../lib/minions/functions/reducedTimeFromKC';
+import { UserSettings } from '../../lib/settings/types/UserSettings';
+import { formatItemReqs } from '../../lib/util/formatItemReqs';
+import { formatItemBoosts } from '../../lib/util/formatItemBoosts';
+import { Time } from '../../lib/constants';
+import { requiresMinion } from '../../lib/minions/decorators';
+
+export default class MinionCommand extends BotCommand {
+	public constructor(store: CommandStore, file: string[], directory: string) {
+		super(store, file, directory, {
+			oneAtTime: true,
+			cooldown: 1,
+			usage: '[name:...string]'
+		});
+	}
+
+	@requiresMinion
+	async run(msg: KlasaMessage, [name = '']: [string]) {
+		const monster = findMonster(name);
+
+		if (!monster) {
+			throw `Thats not a valid monster to kill. Valid monsters are ${killableMonsters
+				.map(mon => mon.name)
+				.join(', ')}.`;
+		}
+
+		const userKc = msg.author.settings.get(UserSettings.MonsterScores)[monster.id] ?? 0;
+		let [timeToFinish, percentReduced] = reducedTimeFromKC(monster, userKc);
+
+		if (monster.itemInBankBoosts) {
+			for (const [itemID, boostAmount] of Object.entries(monster.itemInBankBoosts)) {
+				if (!msg.author.hasItemEquippedOrInBank(parseInt(itemID))) continue;
+				timeToFinish *= (100 - boostAmount) / 100;
+			}
+		}
+
+		const str = [];
+
+		const QP = msg.author.settings.get(UserSettings.QP);
+		if (monster.qpRequired) {
+			str.push(
+				`${monster.name} requires ${monster.qpRequired}qp to kill, and you have ${QP}qp.\n`
+			);
+		}
+		if (monster.itemsRequired && monster.itemsRequired.length > 0) {
+			str.push(
+				`These items are required to kill ${monster.name}: ${formatItemReqs(
+					monster.itemsRequired
+				)}\n`
+			);
+		}
+		if (monster.itemInBankBoosts) {
+			str.push(
+				`These items provide boosts for ${monster.name}: ${formatItemBoosts(
+					monster.itemInBankBoosts
+				)}.\n`
+			);
+		}
+
+		const maxCanKill = Math.floor(msg.author.maxTripLength / timeToFinish);
+		str.push(
+			`The normal time to kill ${monster.name} is ${formatDuration(monster.timeToFinish)}.`
+		);
+
+		const kcForOnePercent = Math.ceil((Time.Hour * 5) / monster.timeToFinish);
+		str.push(
+			`This time can be reduced through experience gained by killing the monster, every ${kcForOnePercent}kc you will gain a 1% boost to kill efficiency up to a maximum of 10% at ${kcForOnePercent *
+				10}kc.`
+		);
+
+		str.push(
+			`You currently recieve a ${percentReduced}% efficiency bonus with your ${userKc}kc.\n`
+		);
+
+		str.push(
+			`The maximum time your minion can be out on a trip is ${formatDuration(
+				msg.author.maxTripLength
+			)}.`
+		);
+
+		str.push(
+			`This means the most you can kill with your current item and KC boosts is ${maxCanKill} with a time per kill of ${formatDuration(
+				timeToFinish
+			)}.\n`
+		);
+
+		const min = timeToFinish * maxCanKill * 1.01;
+		const max = timeToFinish * maxCanKill * 1.2;
+		str.push(
+			`Due to the random variation of an added 1-20% duration, ${maxCanKill}x kills will take from (${formatDuration(
+				min
+			)}) to (${formatDuration(max)}) to finish.\n`
+		);
+
+		if (isWeekend()) {
+			str.push(
+				`Because of the 10% weekend boost it will now take from (${formatDuration(
+					min * 0.9
+				)}) to (${formatDuration(max * 0.9)}) to finish.\n`
+			);
+		}
+
+		return msg.send(str.join('\n'));
+	}
+}

--- a/src/lib/util/formatItemBoosts.ts
+++ b/src/lib/util/formatItemBoosts.ts
@@ -1,0 +1,10 @@
+import { itemNameFromID } from '../util';
+import { Bank } from '../types';
+
+export function formatItemBoosts(items: Bank) {
+	const str = [];
+	for (const [itemID, boostAmount] of Object.entries(items)) {
+		str.push(`${boostAmount}% for ${itemNameFromID(parseInt(itemID))}`);
+	}
+	return str.join(', ');
+}


### PR DESCRIPTION
### Description:

`testkill` - a command to show the user information on a potential trip to kill a monster
	- Shows qp and items required to kill the monster if they exist
	- All items that boost the monster and their respective boost amounts	
	- Displays standard time to kill for that monster 
	- Explains reducedTimeFromKC by showing how many kc per % and a max of 10% available
	- Shows the user the maximum amount killable with their time allowed adjusted for kc and item boosts
	- Explains the 1-20% random duration added on to the trip

![example](https://user-images.githubusercontent.com/7191512/81992739-37ebcf00-9612-11ea-8aaa-33fdd1578661.png)



### Changes:

creation of `testkill.ts` for minions
creation of `formatItemBoosts.ts` file containing the method to accept a bank and return a csv of each item and its respective boost amount

-   [x] I have tested all my changes thoroughly.
