### PR TITLE
check minion ownership with equip and unequip

### DIFF
--- a/src/commands/Minion/equip.ts
+++ b/src/commands/Minion/equip.ts
@@ -7,6 +7,7 @@ import readableGearTypeName from '../../lib/gear/functions/readableGearTypeName'
 import resolveGearTypeSetting from '../../lib/gear/functions/resolveGearTypeSetting';
 import { EquipmentSlot } from 'oldschooljs/dist/meta/types';
 import { itemNameFromID } from '../../lib/util';
+import { requiresMinion } from '../../lib/minions/decorators';
 
 export default class extends BotCommand {
 	public constructor(store: CommandStore, file: string[], directory: string) {
@@ -19,6 +20,7 @@ export default class extends BotCommand {
 		});
 	}
 
+	@requiresMinion
 	async run(
 		msg: KlasaMessage,
 		[gearType, quantity = 1, itemName = '']: [GearTypes.GearSetupTypes, number, string]

--- a/src/commands/Minion/unequip.ts
+++ b/src/commands/Minion/unequip.ts
@@ -5,6 +5,7 @@ import getOSItem from '../../lib/util/getOSItem';
 import { GearTypes } from '../../lib/gear';
 import readableGearTypeName from '../../lib/gear/functions/readableGearTypeName';
 import resolveGearTypeSetting from '../../lib/gear/functions/resolveGearTypeSetting';
+import { requiresMinion } from '../../lib/minions/decorators';
 
 export default class extends BotCommand {
 	public constructor(store: CommandStore, file: string[], directory: string) {
@@ -17,6 +18,7 @@ export default class extends BotCommand {
 		});
 	}
 
+	@requiresMinion
 	async run(
 		msg: KlasaMessage,
 		[gearType, itemName]: [GearTypes.GearSetupTypes, string]


### PR DESCRIPTION
### Description:

require minion for equip and unequip, for some reason people are losing gear after a bot reboot and i thin its the same problem that causes it to forget you own a minion on your first command.  this would prevent it from equiping an item on an empty gear set and reseting the persons gear, at least if the base problem is the caching one.

### Changes:

-   _List of changes here_

-   [] I have tested all my changes thoroughly.
