### PR TITLE
craft: throw when less than qty required of gp

### DIFF
--- a/src/commands/Minion/craft.ts
+++ b/src/commands/Minion/craft.ts
@@ -79,8 +79,8 @@ export default class extends BotCommand {
 				const id = parseInt(itemID);
 				if (id === 995) {
 					const userGP = msg.author.settings.get(UserSettings.GP);
-					if (!userGP) {
-						throw `You have no GP.`;
+					if (userGP < qty) {
+						throw `You do not have enough GP.`;
 					}
 					quantity = Math.min(quantity, Math.floor(userGP / qty));
 					continue;


### PR DESCRIPTION
### Description:

if the user had >0 but < qty it wouldn't throw and instead craft a quantity of 0 items on the trip

### Changes:

-   _List of changes here_

-   [] I have tested all my changes thoroughly.
