### PR TITLE
Fix Groupkill Mass Character Limit Bug

### DIFF
--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -304,7 +304,7 @@ export async function arrIDToUsers(client: KlasaClient, ids: string[]) {
 	return Promise.all(ids.map(id => client.users.fetch(id)));
 }
 
-//now splits a message into 2 if it is over the 2k character limit and under 4k characters
+// now splits a message into 2 if it is over the 2k character limit and under 4k characters
 export async function queuedMessageSend(client: KlasaClient, channelID: string, str: string) {
 	const channel = client.channels.get(channelID);
 	if (!channelIsSendable(channel)) return;

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -304,8 +304,9 @@ export async function arrIDToUsers(client: KlasaClient, ids: string[]) {
 	return Promise.all(ids.map(id => client.users.fetch(id)));
 }
 
+//now splits a message into 2 if it is over the 2k character limit and under 4k characters
 export async function queuedMessageSend(client: KlasaClient, channelID: string, str: string) {
 	const channel = client.channels.get(channelID);
 	if (!channelIsSendable(channel)) return;
-	client.queuePromise(() => channel.send(str));
+	client.queuePromise(() => channel.send(str, {split:true}));
 }

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -308,5 +308,5 @@ export async function arrIDToUsers(client: KlasaClient, ids: string[]) {
 export async function queuedMessageSend(client: KlasaClient, channelID: string, str: string) {
 	const channel = client.channels.get(channelID);
 	if (!channelIsSendable(channel)) return;
-	client.queuePromise(() => channel.send(str, {split:true}));
+	client.queuePromise(() => channel.send(str, { split: true }));
 }

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -304,7 +304,6 @@ export async function arrIDToUsers(client: KlasaClient, ids: string[]) {
 	return Promise.all(ids.map(id => client.users.fetch(id)));
 }
 
-// now splits a message into 2 if it is over the 2k character limit and under 4k characters
 export async function queuedMessageSend(client: KlasaClient, channelID: string, str: string) {
 	const channel = client.channels.get(channelID);
 	if (!channelIsSendable(channel)) return;


### PR DESCRIPTION
### Description:

- Allows messages over Discord's 2k character limit to be split into 2 messages, which would otherwise not show at all.

### Changes:

-   Modified a function to allow for splitting if the message is over the character limit.

**-   [X] I have tested all my changes thoroughly.**
