### PR TITLE
Names as aliases

### DIFF
--- a/src/lib/filterables.ts
+++ b/src/lib/filterables.ts
@@ -746,12 +746,12 @@ export const filterableTypes = [
 	},
 	{
 		name: 'Cerberus',
-		aliases: ['cerb', 'ce'],
+		aliases: ['cerb', 'ce', 'cerberus'],
 		items: cerberus
 	},
 	{
 		name: 'Zulrah',
-		aliases: ['zul', 'zulr'],
+		aliases: ['zul', 'zulr', 'zulrah'],
 		items: zulrah
 	},
 	{

--- a/src/lib/filterables.ts
+++ b/src/lib/filterables.ts
@@ -435,14 +435,19 @@ const zulrah = resolveItems([
 	'Magic fang',
 	'Serpentine visage',
 	'Uncut onyx',
+	'Onyx',
 	'Zul-andra teleport',
 	'Jar of swamp',
 	'Pet snakeling',
 	'Tanzanite helm',
 	'Magma helm',
+	'Toxic staff (uncharged)',
+	'Toxic staff of the dead',
 	'Toxic blowpipe',
+	'Toxic blowpipe (uncharged)',
 	'Uncharged toxic trident',
 	'Trident of the swamp',
+	'Serpentine helm (uncharged)',
 	'Serpentine helm'
 ]);
 


### PR DESCRIPTION

### Description:

Zulrah and Cerb bank filters list weren't accepting boss names as a filterable tag, Zulrah filter was incomplete

### Changes:

Added "Zulrah" and "Cerberus" as alias terms for their respective bank filters so they could be used as tags themselves rather than just the contents of their alias lists as seemed to be the case. Added missing Zulrah items like uncharged variants. 

See Above

-   [] I have not tested all my changes thoroughly, but it's just bank filters.
